### PR TITLE
Fix: Move BrowserRouter to main.tsx to avoid nested router error

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,20 +1,15 @@
-
-import { BrowserRouter as Router, Routes, Route } from "react-router";
+import { Routes, Route } from "react-router";
 import Login from "./pages/Login";
 import SignUp from "./pages/SignUp";
 import "./App.css";
 
 function App() {
   return (
-    <Router>
-      <Routes>
-        <Route path="/login" element={<Login />} />
-        <Route path="/signup" element={<SignUp />} />
-
-        <Route path="*" element={<Login />} />
-      </Routes>
-    </Router>
-
+    <Routes>
+      <Route path="/login" element={<Login />} />
+      <Route path="/signup" element={<SignUp />} />
+      <Route path="*" element={<Login />} />
+    </Routes>
   );
 }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,13 +1,14 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import "./index.css";
-import App from "./App.tsx";
 import { BrowserRouter } from "react-router";
+import App from "./App.tsx";
+import "./index.css";
 
 createRoot(document.getElementById("root")!).render(
-  <BrowserRouter>
-    <StrictMode>
+  <StrictMode>
+    <BrowserRouter>
       <App />
-    </StrictMode>
-  </BrowserRouter>
+    </BrowserRouter>
+  </StrictMode>
 );
+


### PR DESCRIPTION
## Description  
Moved `<BrowserRouter>` from `App.tsx` to `main.tsx` to resolve the error caused by having multiple Routers rendered in the app.

## Related Issue  
N/A

## Changes Made  
- [x] Bug fix  

## How to Test  
1. Start the dev server (`npm run dev` or `yarn dev`)  
2. Navigate to `/login`, `/signup`, or any undefined route  
3. Ensure there are no console errors and routing works as expected  

## Screenshots  
N/A

## Checklist  
- [x] My code follows the project’s coding style.  
- [x] I have tested the changes locally.  
- [x] No console errors/warnings remain.  

## Technical Challenges (optional)  
None — just ensured `BrowserRouter` is used at the root level to prevent double rendering errors.
